### PR TITLE
Add support for F# ticked function names

### DIFF
--- a/src/PrettierTestLogger/LogEntryBuilder.cs
+++ b/src/PrettierTestLogger/LogEntryBuilder.cs
@@ -12,6 +12,18 @@ namespace PrettierTestLogger
         {
             var testResultDisplayNameParts = testResult.DisplayName.Split('.').ToList();
 
+            if (testResult.DisplayName.Contains(' '))
+            {
+                // Assume that tests that contain spaces are already formatted
+                return new LogEntry
+                {
+                    TestClass = testResultDisplayNameParts[0],
+                    Test = String.Join(".", testResultDisplayNameParts.Skip(1)),
+                    Outcome = testResult.Outcome,
+                    DurationMs = (int)testResult.Duration.TotalMilliseconds,
+                };
+            }
+
             if (testResultDisplayNameParts.Count < 2)
             {
                 // This is a best effort try if things go wrong

--- a/test/PrettierTestLogger.Tests/LogEntryBuilderTests.cs
+++ b/test/PrettierTestLogger.Tests/LogEntryBuilderTests.cs
@@ -86,7 +86,7 @@ namespace PrettierTestLogger.Tests
             Assert.Equal("should not split ABBREVATIONS", logEntry.Test);
         }
 
-       [Fact]
+        [Fact]
         public void Should_Not_Split_Abbrevations_In_Uppercase_Within_Text()
         {
             var builder = new LogEntryBuilder();
@@ -95,6 +95,27 @@ namespace PrettierTestLogger.Tests
             var logEntry = builder.BuildLogEntry(testResult);
             Assert.Equal("should not split ABBREVATIONS in text", logEntry.Test);
         }
+
+        [Fact]
+        public void Should_Handle_Ticked_Function_Names()
+        {
+            var builder = new LogEntryBuilder();
+            var testResult = BuildTestResultFromDisplayName("PrettierTestLogger.Should handle ticked function names");
+
+            var logEntry = builder.BuildLogEntry(testResult);
+            Assert.Equal("Should handle ticked function names", logEntry.Test);
+        }
+
+        [Fact]
+        public void Should_Handle_Ticked_Function_Names_With_Special_Characters()
+        {
+            var builder = new LogEntryBuilder();
+            var testResult = BuildTestResultFromDisplayName("PrettierTestLogger.Should handle ticked function names with special characters, e.g. these ones");
+
+            var logEntry = builder.BuildLogEntry(testResult);
+            Assert.Equal("Should handle ticked function names with special characters, e.g. these ones", logEntry.Test);
+        }
+
         private TestResult BuildTestResultFromDisplayName(string displayName)
         {
             return new TestResult(new TestCase { DisplayName = displayName }) {


### PR DESCRIPTION
According to the F# spec:

> Any sequence of characters that is enclosed in double-backtick marks (`` ``), excluding newlines, tabs, and double-backtick pairs themselves, is treated as an identifier. 

Tests written in F# often take advantage of this to get wonderfully expressive test names. This patch simply skips formatting of test names for such cases because we can no longer assume that periods indicate namespacing or attribute accesses.